### PR TITLE
Add dco icon to dco publications in search results

### DIFF
--- a/html/publications.html
+++ b/html/publications.html
@@ -50,6 +50,10 @@
                     var doiUrl = "https://dx.doi.org/"+record["doi"];
 
                     var html = "<tr><td>";
+                    
+                    if (record["isDcoPublication"]) {
+                        html += "<img style='vertical-align: middle' src='//deepcarbon.net/sites/default/files/images/dco-icon-footer_0.png' height='15' width='15'>&nbsp;";
+                    }
 
                     if (record["doi"]) {
                         html += "<strong><a href=\""+doiUrl+"\" target=\"_blank\">" + record["title"] + "</a></strong>";


### PR DESCRIPTION
If you like the positioning and size of the DCO icon we can close this ticket out :smile: 

In test at https://dcotest.tw.rpi.edu/browsers2/publications.html
