### PR TITLE
add dco icon to "dco publication" checkbox text

### DIFF
--- a/html/publications.html
+++ b/html/publications.html
@@ -146,7 +146,7 @@
         // add the DCO publication control checkbox to the interface
         // TODO move to a pre_search_callback?
         $(".facetview_search_options_container")
-                .after("<input id='is-dco-publication-checkbox' type='checkbox'>&nbsp;Only show DCO-member authored publications</input>");
+                .after("<input id='is-dco-publication-checkbox' type='checkbox'>&nbsp;Only show DCO-member authored publications</input>&nbsp;<img style='vertical-align: middle' src='//deepcarbon.net/sites/default/files/images/dco-icon-footer_0.png' height='15' width='15'>");
 
         // set checkbox to control isDcoPublication filter on selection/deselection
         $("#is-dco-publication-checkbox")


### PR DESCRIPTION
I have added the DCO icon to the checkbox text as an indication to the user that the icon is later used to identify that a publication is a "DCO publication"

Available in test at https://dcotest.tw.rpi.edu/browsers2/publications.html

![screen shot 2015-08-03 at 8 50 01 am](https://cloud.githubusercontent.com/assets/1057295/9040050/b2afa818-39bc-11e5-89a7-65f1b19c492a.png)
