### PR TITLE
add publication capabilities to ingest script

### DIFF
--- a/ingest/ingest-publications.py
+++ b/ingest/ingest-publications.py
@@ -177,12 +177,12 @@ def has_type(resource, type):
     return False
 
 
-def publish(bulk, endpoint, rebuild_index, mapping):
+def publish(bulk, endpoint, rebuild, mapping):
 
     # if configured to rebuild_index
     # Delete and then re-create to publication index (via PUT request)
 
-    if rebuild_index:
+    if rebuild:
         requests.delete(endpoint)
         r = requests.put(endpoint)
         if r.status_code != requests.codes.ok:
@@ -220,8 +220,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--threads', default=8, help='number of threads to use (default = 8)')
     parser.add_argument('--es', default="http://data.deepcarbon.net/es", help="elasticsearch service URL")
-    parser.add_argument('--publish', default=False, help="publish to elasticsearch? (default = False)")
-    parser.add_argument('--rebuild-index', default=False, help="rebuild elasticsearch index? (default = False)")
+    parser.add_argument('--publish', default=False, action="store_true", help="publish to elasticsearch?")
+    parser.add_argument('--rebuild', default=False, action="store_true", help="rebuild elasticsearch index?")
     parser.add_argument('--mapping', default="../mappings/publication.json", help="publication elasticsearch mapping document")
     parser.add_argument('out', metavar='OUT', help='elasticsearch bulk ingest file')
 
@@ -236,4 +236,4 @@ if __name__ == "__main__":
 
     # publish the results to elasticsearch if "--publish" was specified on the command line
     if args.publish:
-        publish(bulk=records, endpoint=args.es, rebuild_index=args.rebuild_index, mapping=args.mapping)
+        publish(bulk=records, endpoint=args.es, rebuild=args.rebuild, mapping=args.mapping)

--- a/ingest/ingest-publications.py
+++ b/ingest/ingest-publications.py
@@ -244,7 +244,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # generate bulk import document for publications
-    records = generate(threads=args.threads, sparql=args.sparql)
+    records = generate(threads=int(args.threads), sparql=args.sparql)
 
     # save generated bulk import file so it can be backed up or reviewed if there are publish errors
     with open(args.out, "w") as bulk_file:

--- a/ingest/ingest-publications.py
+++ b/ingest/ingest-publications.py
@@ -7,6 +7,8 @@ import multiprocessing
 import itertools
 import argparse
 import requests
+import warnings
+import pprint
 
 
 def load_file(filepath):
@@ -134,7 +136,10 @@ def create_publication_doc(publication, endpoint):
 
     subject_areas = []
     for subject_area in pub.objects(VIVO.hasSubjectArea):
-        subject_areas.append({"uri": str(subject_area.identifier), "name": subject_area.label().toPython()})
+        sa = {"uri": str(subject_area.identifier)}
+        if subject_area.label():
+            sa.update({"name": subject_area.label().toPython()})
+        subject_areas.append(sa)
 
     if subject_areas:
         doc.update({"subjectArea": subject_areas})
@@ -153,7 +158,8 @@ def create_publication_doc(publication, endpoint):
         if rank:
             obj.update({"rank": rank})
 
-        research_areas = [research_area.label().toPython() for research_area in author.objects(VIVO.hasResearchArea)]
+        research_areas = [research_area.label().toPython() for research_area in author.objects(VIVO.hasResearchArea) if research_area.label()]
+
         if research_areas:
             obj.update({"researchArea": research_areas})
 

--- a/ingest/ingest-publications.py
+++ b/ingest/ingest-publications.py
@@ -59,7 +59,7 @@ def process_publication(publication):
 
 
 def describe_publication(publication):
-    q = describe_publication_query.replace("?publication", "<"+publication+">")
+    q = describe_publication_query.replace("?publication", "<" + publication + ">")
     sparql.setQuery(q)
 
     try:
@@ -98,9 +98,11 @@ def create_publication_doc(publication):
         doc.update({"abstract": abstract})
 
     most_specific_type = list(pub.objects(VITRO.mostSpecificType))
-    most_specific_type = most_specific_type[0].label().toPython() if most_specific_type and most_specific_type[0].label() else None
+    most_specific_type = most_specific_type[0].label().toPython() \
+        if most_specific_type and most_specific_type[0].label() \
+        else None
     if most_specific_type:
-            doc.update({"mostSpecificType": most_specific_type})
+        doc.update({"mostSpecificType": most_specific_type})
 
     publication_year = list(pub.objects(DCO.yearOfPublication))
     publication_year = publication_year[0] if publication_year else None
@@ -178,11 +180,10 @@ def has_type(resource, type):
 
 
 def publish(bulk, endpoint, rebuild, mapping):
-
     # if configured to rebuild_index
     # Delete and then re-create to publication index (via PUT request)
 
-    index_url = endpoint+"/dco"
+    index_url = endpoint + "/dco"
 
     if rebuild:
         requests.delete(index_url)
@@ -193,7 +194,7 @@ def publish(bulk, endpoint, rebuild, mapping):
 
     # push current publication document mapping
 
-    mapping_url = endpoint+"/dco/publication/_mapping"
+    mapping_url = endpoint + "/dco/publication/_mapping"
     with open(mapping) as mapping_file:
         r = requests.put(mapping_url, data=mapping_file)
         if r.status_code != requests.codes.ok:
@@ -208,7 +209,7 @@ def publish(bulk, endpoint, rebuild, mapping):
                 r.raise_for_status()
 
     # bulk import new publication documents
-    bulk_import_url = endpoint+"/_bulk"
+    bulk_import_url = endpoint + "/_bulk"
     r = requests.post(bulk_import_url, data=bulk)
     if r.status_code != requests.codes.ok:
         print(r.url, r.status_code)
@@ -227,7 +228,7 @@ if __name__ == "__main__":
     parser.add_argument('--es', default="http://data.deepcarbon.net/es", help="elasticsearch service URL")
     parser.add_argument('--publish', default=False, action="store_true", help="publish to elasticsearch?")
     parser.add_argument('--rebuild', default=False, action="store_true", help="rebuild elasticsearch index?")
-    parser.add_argument('--mapping', default="../mappings/publication.json", help="publication elasticsearch mapping document")
+    parser.add_argument('--mapping', default="mappings/publication.json", help="publication elasticsearch mapping document")
     parser.add_argument('out', metavar='OUT', help='elasticsearch bulk ingest file')
 
     args = parser.parse_args()
@@ -241,4 +242,5 @@ if __name__ == "__main__":
 
     # publish the results to elasticsearch if "--publish" was specified on the command line
     if args.publish:
-        publish(bulk=records, endpoint=args.es, rebuild=args.rebuild, mapping=args.mapping)
+        bulk_str = '\n'.join(records)
+        publish(bulk=bulk_str, endpoint=args.es, rebuild=args.rebuild, mapping=args.mapping)

--- a/ingest/ingest-publications.py
+++ b/ingest/ingest-publications.py
@@ -182,10 +182,13 @@ def publish(bulk, endpoint, rebuild, mapping):
     # if configured to rebuild_index
     # Delete and then re-create to publication index (via PUT request)
 
+    index_url = endpoint+"/dco"
+
     if rebuild:
-        requests.delete(endpoint)
-        r = requests.put(endpoint)
+        requests.delete(index_url)
+        r = requests.put(index_url)
         if r.status_code != requests.codes.ok:
+            print(r.url, r.status_code)
             r.raise_for_status()
 
     # push current publication document mapping
@@ -201,12 +204,14 @@ def publish(bulk, endpoint, rebuild, mapping):
             requests.delete(mapping_url)
             r = requests.put(mapping_url, data=mapping_file)
             if r.status_code != requests.codes.ok:
+                print(r.url, r.status_code)
                 r.raise_for_status()
 
     # bulk import new publication documents
     bulk_import_url = endpoint+"/_bulk"
     r = requests.post(bulk_import_url, data=bulk)
     if r.status_code != requests.codes.ok:
+        print(r.url, r.status_code)
         r.raise_for_status()
 
 

--- a/ingest/requirements.txt
+++ b/ingest/requirements.txt
@@ -1,2 +1,3 @@
 rdflib>=4.2
 SPARQLWrapper>= 1.6.4
+requests>=2.7.0


### PR DESCRIPTION
Updated publication ingest script to be able to push the new elasticsearch documents to the elastic search service.

```
usage: ingest-publications.py [-h] [--threads THREADS] [--es ES] [--publish]
                              [--rebuild] [--mapping MAPPING]
                              OUT

positional arguments:
  OUT                elasticsearch bulk ingest file

optional arguments:
  -h, --help         show this help message and exit
  --threads THREADS  number of threads to use (default = 8)
  --es ES            elasticsearch service URL
  --publish          publish to elasticsearch?
  --rebuild          rebuild elasticsearch index?
  --mapping MAPPING  publication elasticsearch mapping document

```
