### PR TITLE
Fix bug in people browser caused by missing DCO-ID

### DIFF
--- a/html/people.html
+++ b/html/people.html
@@ -25,7 +25,11 @@
                     {{#if thumbnail}}<img src="{{thumbnail}}">{{/if}}
                     <div class="caption">
                         <h5><small>
+                            {{#if dcoId}}
                             <a class="{{#if isDcoMember}}dco-logo{{/if}}" href="{{dcoId}}" target="_blank">{{name}}</a>
+                            {{else}}
+                            <a class="{{#if isDcoMember}}dco-logo{{/if}}" href="{{uri}}" target="_blank">{{name}}</a>
+                            {{/if}}
                         </small></h5>
                     </div>
                 </div>
@@ -55,7 +59,7 @@
 
                     <div>
                         {{#if orcid}}<a href="{{orcidURL orcid}}" target="_blank"><img class="badge" src="{{orcidBadgeURL orcid}}"/></a>{{/if}}
-                        <a href="{{dcoId}}" target="_blank"><img class="badge" src="{{dcoIdBadgeURL dcoId}}"/></a>
+                        {{#if dcoId}}<a href="{{dcoId}}" target="_blank"><img class="badge" src="{{dcoIdBadgeURL dcoId}}"/></a>{{/if}}
                     </div>
 
                 </div>


### PR DESCRIPTION
Added check for presence of dcoId when generating result HTML. If no dcoId, use URI in name link and do not show DCO-ID badge.

This update has been applied to the UDCO browser available at http://udco.tw.rpi.edu/vivo/people-test

https://jira.tw.rpi.edu/browse/DCO-368

A question before closing this ticket - should we show a VIVO profile badge if there is no DCO-ID?  We could generate one with the non-DCO-ID URI.
