### PR TITLE
Removing the Type facet from the people browser

### DIFF
--- a/html/people.html
+++ b/html/people.html
@@ -137,7 +137,6 @@
                 default_facet_order: "count",
                 default_facet_size: 15,
                 facets: [
-                    {'field': 'mostSpecificType.exact', 'display': 'Type'},
                     {'field': 'dcoCommunities.name.exact', 'display': 'Community'},
                     {'field': 'portalGroups.name.exact', 'display': 'Portal Group'},
                     {'field': 'organization.name.exact', 'display': 'Organization'},


### PR DESCRIPTION
After discussions with engagement and secretariat we agreed that the
type facet in the people browser didn't make much sense. No one is going
to search by people who are professors. The other issue is that any new
people added to the system for the last 10 months at least don't have a
type, they are just Person. So removing the facet.
